### PR TITLE
opam: explicitely depend on dune-configurator

### DIFF
--- a/ahrocksdb.opam
+++ b/ahrocksdb.opam
@@ -8,7 +8,8 @@ dev-repo: "https://github.com/ahrefs/ocaml-ahrocksdb.git"
 bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 available: [ ocaml-version >= "4.06.0"]
 depends: [
-  "dune" {build}
+  "dune"
+  "dune-configurator"
   "ctypes" {>="0.12.0"}
   "astring"
   "conf-rocksdb"

--- a/ffi/lib/config/dune
+++ b/ffi/lib/config/dune
@@ -1,3 +1,3 @@
 (executable
  (name discover)
- (libraries dune.configurator))
+ (libraries dune-configurator))


### PR DESCRIPTION
The library used to be provided by dune. But it is now in its own package.
Ahrocksdb can be installed in switches by accident as dune and dune-configurator
are often present. But there are cases where it will fail to install.