### PR TITLE
support xpress and zstd compression

### DIFF
--- a/ffi/bindings/views.ml
+++ b/ffi/bindings/views.ml
@@ -20,6 +20,8 @@ let int_of_compression = function
   | `Bz2 -> 3
   | `Lz4 -> 4
   | `Lz4hc -> 5
+  | `Xpress -> 6
+  | `Zstd -> 7
 
 let compression_view =
   let read = function
@@ -29,6 +31,8 @@ let compression_view =
     | 3 -> `Bz2
     | 4 -> `Lz4
     | 5 -> `Lz4hc
+    | 6 -> `Xpress
+    | 7 -> `Zstd
     | other -> invalid_arg @@ Printf.sprintf "read_compression_view: invalid compression type: %d" other
   in
   let write = int_of_compression in

--- a/lib/rocksdb.mli
+++ b/lib/rocksdb.mli
@@ -110,11 +110,23 @@ module Options : sig
 
   end
 
+  (** Compression algorithms supported by RocksDB *)
+  type compression = [
+    | `Bz2
+    | `Lz4
+    | `Lz4hc
+    | `No_compression
+    | `Snappy
+    | `Xpress
+    | `Zlib
+    | `Zstd
+  ]
+
   (** RocksDB main configuration record *)
   type config = {
     parallelism_level : int option; (** Number of background processes used by RocksDB *)
-    base_compression : [ `Bz2 | `Lz4 | `Lz4hc | `No_compression | `Snappy | `Zlib ]; (** Compression algorithm used to compact data at base level*)
-    compression_by_level : [ `Bz2 | `Lz4 | `Lz4hc | `No_compression | `Snappy | `Zlib ] list; (** Compression algorithm used to compact data in order for each level*)
+    base_compression : compression; (** Compression algorithm used to compact data at base level*)
+    compression_by_level : compression list; (** Compression algorithm used to compact data in order for each level*)
     optimize_filters_for_hits: bool option;
     disable_compaction : bool; (** Disable compaction: data will not be compressed, but manual compaction can still be issued *)
     max_flush_processes : int option; (** Number of background workers dedicated to flush *)

--- a/lib/rocksdb_options.ml
+++ b/lib/rocksdb_options.ml
@@ -57,10 +57,21 @@ let create () =
   Gc.finalise destroy t;
   t
 
+type compression = [
+  | `Bz2
+  | `Lz4
+  | `Lz4hc
+  | `No_compression
+  | `Snappy
+  | `Xpress
+  | `Zlib
+  | `Zstd
+]
+
 type config = {
     parallelism_level : int option;
-    base_compression : [ `Bz2 | `Lz4 | `Lz4hc | `No_compression | `Snappy | `Zlib ];
-    compression_by_level : [ `Bz2 | `Lz4 | `Lz4hc | `No_compression | `Snappy | `Zlib ] list;
+    base_compression : compression;
+    compression_by_level : compression list;
     optimize_filters_for_hits: bool option;
     disable_compaction : bool;
     max_flush_processes : int option;


### PR DESCRIPTION
This makes available two compression algorithms, Xpress and zstd, that are supported by Rocksdb but currently absent from the bindings. Their enum values are 6 and 7 respectively [in the C api](https://github.com/facebook/rocksdb/blob/3622cfa34aca061eaf0595c5fa711f2b34fd3a07/include/rocksdb/c.h#L1580-L1581).