### PR TITLE
Compile include test with c++

### DIFF
--- a/ffi/lib/config/discover.ml
+++ b/ffi/lib/config/discover.ml
@@ -26,7 +26,7 @@ int main() {
 |}
 in
 
-let c_flag = List.find_opt (fun c_flag -> C.c_test c ~c_flags:["-I" ^ c_flag] ~link_flags include_test) known_paths in
+let c_flag = List.find_opt (fun c_flag -> C.c_test c ~c_flags:["-I" ^ c_flag; "-x"; "c++"] ~link_flags include_test) known_paths in
 
 match c_flag with
 | None ->


### PR DESCRIPTION
Fixes #4. This commit from rocksdb https://github.com/facebook/rocksdb/commit/0a9a05ae12943b1529ef1eabbca5ce5a71c986bf included the C++ `<string>` header, so we are including the c++ flag à la https://github.com/ocaml/dune/issues/2578. 