### PR TITLE
discover: compare RocksDB version numerically, not lexicographically

### DIFF
--- a/ffi/lib/config/discover.ml
+++ b/ffi/lib/config/discover.ml
@@ -1,6 +1,6 @@
 open Printf
 
-let minimum_rocks_version = "5.14"
+let minimum_rocks_major, minimum_rocks_minor = 5, 14
 
 module C = Configurator.V1
 
@@ -52,8 +52,8 @@ match c_flag with
 
    let major = expect_int "ROCKSDB_MAJOR" in
    let minor = expect_int "ROCKSDB_MINOR" in
-   let version = sprintf "%d.%d" major minor in
-   if (String.compare minimum_rocks_version version) > 0 then failwith (sprintf "installed RocksDB installation is too old: found %s, expected %s minimum" version minimum_rocks_version);
+   if (major, minor) < (minimum_rocks_major, minimum_rocks_minor) then
+     failwith (sprintf "installed RocksDB installation is too old: found %d.%d, expected %d.%d minimum" major minor minimum_rocks_major minimum_rocks_minor);
 
    C.Flags.write_sexp "c_flags.sexp"         ["-I" ^ c_flag];
    C.Flags.write_sexp "c_library_flags.sexp" link_flags;


### PR DESCRIPTION
Fixes #7.

The minimum-version check in `ffi/lib/config/discover.ml` used `String.compare` on `"M.m"` strings. Lexicographically, `"10.4" < "5.14"` (because `'1' < '5'`), so any RocksDB with major version >= 10 was rejected as "too old":

```
Error: failure: installed RocksDB installation is too old: found 10.4, expected 5.14 minimum
```

This patch keeps the minimum as a pair of ints and compares tuples (`<` on tuples is structural in OCaml). It also reports the found/required versions with `%d.%d` instead of `%s`.

Verified locally: with this change applied on top of master, `opam install ahrocksdb` succeeds against system RocksDB 10.4 on Ubuntu 25.10.

While you're cutting a release for this, please also see #6 — there has been no opam release since the C++-probe fix from #5 was merged, so 0.2.2 is broken for anyone on rocksdb >= 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
